### PR TITLE
match linter config from 'test-network-function'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 linters-settings:
   dupl:
-    threshold: 20
+    threshold: 75
   funlen:
     lines: 50
     statements: 25
   gci:
     local-prefixes: github.com/golangci/golangci-lint
   goconst:
-    min-len: 2
+    min-len: 4
     min-occurrences: 1
   gocritic:
     enabled-tags:
@@ -22,6 +22,8 @@ linters-settings:
       - octalLiteral
       - whyNoLint
       - wrapperFunc
+      - ptrToRefParam
+      - sloppyReassign
   gocyclo:
     min-complexity: 15
   goimports:
@@ -46,13 +48,11 @@ linters-settings:
     line-length: 200
   maligned:
     suggest-new: true
-  misspell:
-    locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-leading-space: false # disallow leading spaces. A space means the //nolint comment shows in `godoc` output.
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
-    require-specific: true # don't require nolint directives to be specific about which linter is being skipped
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
@@ -65,8 +65,8 @@ linters:
     - dupl
     - errcheck
     - exhaustive
+    - exportloopref
     - funlen
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
@@ -86,19 +86,17 @@ linters:
     - noctx
     - nolintlint
     - rowserrcheck
-    - scopelint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
-    - unused
     - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
   # - gochecknoglobals
+  # - gochecknoinits
   # - gocognit
   # - godot
   # - godox
@@ -106,21 +104,28 @@ linters:
   # - maligned
   # - nestif
   # - prealloc
+  # - scopelint
+  # - structcheck
   # - testpackage
+  # - unused
   # - wsl
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
+    # Ignore magic numbers and inline strings in tests.
     - path: _test\.go
       linters:
         - gomnd
-    # https://github.com/go-critic/go-critic/issues/926
+        - goconst
+    # Ignore line length for string assignments (don't try and wrap regex definitions)
     - linters:
         - lll
-      source: "^(// |.*= (\".*\"|`.*`))$"  #Ignore line length for variable assignment and comments
+      source: "^(.*= (\".*\"|`.*`))$"
+    # https://github.com/go-critic/go-critic/issues/926
     - linters:
         - gocritic
       text: "unnecessaryDefer:"
+    # Ignore static strings in tests
 
 
 # golangci.com configuration

--- a/pkg/claim/schema_test.go
+++ b/pkg/claim/schema_test.go
@@ -24,8 +24,8 @@ import (
 
 type testCase struct {
 	expectedMarshallJSONError bool
-	expectedStartTime         string // nolint:structcheck // structcheck incorrectly reports field is unused.
-	expectedEndTime           string // nolint:structcheck // structcheck incorrectly reports field is unused.
+	expectedStartTime         string
+	expectedEndTime           string
 }
 
 var testCases = map[string]*testCase{


### PR DESCRIPTION
Having made some changes to the linter configuration of
'test-network-function' this copies over the updates to
this repo.
They may diverge in the future but at this point there is
not a strong reason for them to so I will favour consistency.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>