### PR TITLE
Manually add version tag

### DIFF
--- a/claim.schema.json
+++ b/claim.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "http://test-network-function.com/schemas/claim.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "version": "v0.0.6",
+  "version": "v0.0.7",
   "description": "A test-network-function claim is an attestation of the tests performed, the results and the various configurations.  Since a claim must be reproducible, it also includes an overview of the systems under test and their physical configurations.",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Versions became mismatched between schema and Go module.
Re-align them appropriately.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>